### PR TITLE
Bugfix login code

### DIFF
--- a/client/src/components/Login/Login.js
+++ b/client/src/components/Login/Login.js
@@ -29,7 +29,7 @@ function Login() {
     onSuccess,
     onFailure,
     clientId,
-    isSignedIn: true,
+    isSignedIn: false,
     scope: "email profile https://www.googleapis.com/auth/drive https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/presentations",
     prompt: "consent",
     responseType: "code",


### PR DESCRIPTION
Quick fix for bug not giving the right format for `sessionObj` on re-deployment or re-login, because of browser caching login information.

I just made it so that the browser doesn't cache login information anymore, this also adds improved privacy as a side effect

Closes #84 